### PR TITLE
Display corequisite courses, optimize graph layout and frontend cache

### DIFF
--- a/components/CourseDescription.tsx
+++ b/components/CourseDescription.tsx
@@ -6,7 +6,7 @@ interface CourseDescriptionProps {
 
 function CourseDescription({ text }: CourseDescriptionProps) {
   // regex capturing groups are included in the array returned from `split()`
-  const splitText = text.split(/((?:Pre|Co)requisites:)/g);
+  const splitText = text.split(/((?:Pre|Co)requisites?:)/g);
   return (
     <p>
       {splitText.map((substring, index) => (

--- a/components/CourseListing.tsx
+++ b/components/CourseListing.tsx
@@ -20,7 +20,7 @@ function CourseListing({ course }: CourseListingProps) {
       {course.successors && (
         <p>
           <strong>
-            {`Prerequisite to ${course.successors.length} other course${
+            {`Prerequisite of ${course.successors.length} other course${
               course.successors.length !== 1 ? "s" : ""
             }`}
           </strong>

--- a/components/graphing/CourseNode.tsx
+++ b/components/graphing/CourseNode.tsx
@@ -32,7 +32,7 @@ function CourseNode({ node, dispatch }: CourseNodeProps) {
   }
   return (
     <g>
-      {node.child && node.state === "open" && (
+      {node.state === "open" && node.child && (
         <Edges.Arrow
           x1={node.child.xOut}
           y1={node.child.y}
@@ -65,6 +65,33 @@ function CourseNode({ node, dispatch }: CourseNodeProps) {
           <a>{node.code}</a>
         </Link>
       </TextWithBackground>
+      {node.state === "open" && node.coreqs && (
+        <>
+          <text
+            x={node.x + vertexRadius + 4}
+            y={node.y + 25}
+            className={styles.setNodeLabel}
+          >
+            COREQUISITE(S)
+          </text>
+          {node.coreqs.map((coreq, index) => (
+            <TextWithBackground
+              key={coreq.code}
+              x={node.x + vertexRadius + 4}
+              y={node.y + (index + 1) * 30 + 10}
+              className={
+                coreq.exists
+                  ? styles.courseNodeLabel
+                  : `${styles.courseNodeLabel} ${styles.courseUnknown}`
+              }
+            >
+              <Link href={`/courses/${slugifyCourseCode(coreq.code)}`}>
+                <a>{coreq.code}</a>
+              </Link>
+            </TextWithBackground>
+          ))}
+        </>
+      )}
     </g>
   );
 }

--- a/components/graphing/TextWithBackground.tsx
+++ b/components/graphing/TextWithBackground.tsx
@@ -51,7 +51,7 @@ function TextWithBackground({
       setVerticalPadding(parseInt(computedStyle["paddingTop"]));
       setHorizontalPadding(parseInt(computedStyle["paddingLeft"]));
     }
-  }, [textRef]);
+  }, [children, textRef]);
 
   const textVerticalOffset = textHeight * VERTICAL_OFFSET_FACTOR;
 

--- a/components/graphing/makeGraph.ts
+++ b/components/graphing/makeGraph.ts
@@ -88,6 +88,7 @@ function courseGraphNodeFactory(code: string, isNested: boolean) {
     y: 0,
     xIn: 0,
     xOut: 0,
+    bounds: { xMin: 0, xMax: 0, yMin: 0, yMax: 0 },
     isNested,
   };
   return node;

--- a/components/graphing/setPositions.ts
+++ b/components/graphing/setPositions.ts
@@ -1,4 +1,9 @@
-import type { AnyGraphNode, BoundingBox } from "../../utils/graph-schema";
+import type {
+  AnyGraphNode,
+  BoundingBox,
+  CourseGraphNode,
+  CourseSetGraphNode,
+} from "../../utils/graph-schema";
 
 const X_INTERVAL = 200;
 const Y_INTERVAL = 40;
@@ -6,6 +11,7 @@ const COURSE_MAX_WIDTH = 110;
 const HORIZONTAL_MARGIN = 10;
 const VERTICAL_PADDING = 20;
 const TOP_EXTRA_PADDING = 10;
+const COURSE_SET_TOP_PADDING = 30;
 
 /**
  * Sets `x`, `y`, `xIn`, `xOut`, `yMin`, and `yMax` where applicable on each
@@ -19,9 +25,9 @@ const TOP_EXTRA_PADDING = 10;
  * representing the bounding box of the tree after the nodes have been
  * positioned
  */
-export function setPositions(root: AnyGraphNode) {
+export function setPositions(root: CourseGraphNode) {
   const nextYCoordinates: number[] = [];
-  setPositionsHelper(root, 0, 0, nextYCoordinates);
+  positionCourse(root, 0, 0, nextYCoordinates);
   const yChange = -root.y;
   adjustPositions(root, yChange);
   const bounds: BoundingBox = {
@@ -50,8 +56,8 @@ export function setPositions(root: AnyGraphNode) {
  * @param nextYCoordinates An array containing the minimum *y* coordinate where
  * a new node can be placed for each level of the tree
  */
-function setPositionsHelper(
-  node: AnyGraphNode,
+function positionCourse(
+  node: CourseGraphNode,
   depth: number,
   yEstimate: number,
   nextYCoordinates: number[]
@@ -64,51 +70,93 @@ function setPositionsHelper(
     node.y = yEstimate;
   }
 
-  if (node.type === "course") {
-    if (node.state === "open" && node.child) {
-      setPositionsHelper(node.child, depth + 1, node.y, nextYCoordinates);
-      node.y = node.child.y;
-    }
-    node.xIn = node.x - HORIZONTAL_MARGIN;
-    node.xOut = node.x + COURSE_MAX_WIDTH;
-    nextYCoordinates[depth] = node.y + Y_INTERVAL;
-  } else {
-    let nextY = Math.max(
-      node.y - ((node.children.length - 1) / 2) * Y_INTERVAL,
-      nextYCoordinates[depth] + TOP_EXTRA_PADDING + Y_INTERVAL / 4
-    );
-    let xMin = node.x;
-    let xMax = node.x;
-    for (const child of node.children) {
-      setPositionsHelper(child, depth, nextY, nextYCoordinates);
-      if (child.xIn < xMin) {
-        xMin = child.xIn;
-      }
-      if (child.xOut > xMax) {
-        xMax = child.xOut;
-      }
-      nextY = nextYCoordinates[depth];
-    }
-    node.bounds.xMin = xMin - HORIZONTAL_MARGIN;
-    node.bounds.xMax = xMax + HORIZONTAL_MARGIN;
-    // `node.children` is assumed to have length at least 2
-    const firstChild = node.children[0];
-    const firstChildY =
-      firstChild.type === "course" ? firstChild.y : firstChild.bounds.yMin;
-    const lastChild = node.children[node.children.length - 1];
-    const lastChildY =
-      lastChild.type === "course" ? lastChild.y : lastChild.bounds.yMax;
-    node.bounds.yMin = firstChildY - (VERTICAL_PADDING + TOP_EXTRA_PADDING);
-    node.bounds.yMax = lastChildY + VERTICAL_PADDING;
-    node.y = (firstChildY + lastChildY) / 2;
-    node.xIn = node.bounds.xMin;
-    if (node.amount === "all" && !node.isNested) {
-      node.xOut = node.x + X_INTERVAL - HORIZONTAL_MARGIN * 2;
+  if (node.state === "open" && node.child) {
+    if (node.child.type === "course") {
+      // single course
+      positionCourse(node.child, depth + 1, node.y, nextYCoordinates);
     } else {
-      node.xOut = node.bounds.xMax;
+      // course set
+      positionSet(node.child, depth + 1, node.y, nextYCoordinates);
     }
-    nextYCoordinates[depth] += Y_INTERVAL / 4;
+    node.y = node.child.y;
   }
+  node.xIn = node.x - HORIZONTAL_MARGIN;
+  node.xOut = node.x + COURSE_MAX_WIDTH;
+  nextYCoordinates[depth] = node.y + Y_INTERVAL;
+}
+
+/**
+ * Recursively sets node `x` and `y` coordinates, as well as `xIn`, `xOut`,
+ * and `bounds` where applicable.
+ *
+ * A node's *x* coordinate is just a function of its "semantic depth" (depth in
+ * the tree where course set nodes do not contribute to depth).
+ *
+ * A node's *y* coordinate is determined based on the provided estimate and the
+ * *y* coordinates of its children. The final *y* coordinate will always be
+ * equal to or greater than `yEstimate`.
+ *
+ * @param node The node to set the position of
+ * @param depth The "semantic depth" of the current node
+ * @param yEstimate The estimated *y* coordinate where `node` should be placed
+ * @param nextYCoordinates An array containing the minimum *y* coordinate where
+ * a new node can be placed for each level of the tree
+ */
+function positionSet(
+  node: CourseSetGraphNode,
+  depth: number,
+  yEstimate: number,
+  nextYCoordinates: number[]
+) {
+  node.x = depth * -X_INTERVAL;
+  if (depth < nextYCoordinates.length) {
+    node.y = Math.max(yEstimate, nextYCoordinates[depth]);
+  } else {
+    nextYCoordinates.push(Number.NEGATIVE_INFINITY);
+    node.y = yEstimate;
+  }
+
+  let nextY = Math.max(
+    node.y - ((node.children.length - 1) / 2) * Y_INTERVAL,
+    nextYCoordinates[depth] + TOP_EXTRA_PADDING + Y_INTERVAL / 4
+  );
+  let xMin = node.x;
+  let xMax = node.x;
+  for (const child of node.children) {
+    if (child.type === "course") {
+      // single course
+      positionCourse(child, depth, nextY, nextYCoordinates);
+    } else {
+      // course set
+      positionSet(child, depth, nextY, nextYCoordinates);
+    }
+    if (child.xIn < xMin) {
+      xMin = child.xIn;
+    }
+    if (child.xOut > xMax) {
+      xMax = child.xOut;
+    }
+    nextY = nextYCoordinates[depth];
+  }
+  node.bounds.xMin = xMin - HORIZONTAL_MARGIN;
+  node.bounds.xMax = xMax + HORIZONTAL_MARGIN;
+  // `node.children` is assumed to have length at least 2
+  const firstChild = node.children[0];
+  const firstChildY =
+    firstChild.type === "course" ? firstChild.y : firstChild.bounds.yMin;
+  const lastChild = node.children[node.children.length - 1];
+  const lastChildY =
+    lastChild.type === "course" ? lastChild.y : lastChild.bounds.yMax;
+  node.bounds.yMin = firstChildY - (VERTICAL_PADDING + TOP_EXTRA_PADDING);
+  node.bounds.yMax = lastChildY + VERTICAL_PADDING;
+  node.y = (firstChildY + lastChildY) / 2;
+  node.xIn = node.bounds.xMin;
+  if (node.amount === "all" && !node.isNested) {
+    node.xOut = node.x + X_INTERVAL - HORIZONTAL_MARGIN * 2;
+  } else {
+    node.xOut = node.bounds.xMax;
+  }
+  nextYCoordinates[depth] += Y_INTERVAL / 4;
 }
 
 /**

--- a/components/graphing/setPositions.ts
+++ b/components/graphing/setPositions.ts
@@ -29,7 +29,9 @@ const SET_HORIZONTAL_PADDING = 10;
 export function setPositions(root: AnyGraphNode) {
   const nextYCoordinates: number[] = [];
   positionNode(root, 0, 0, nextYCoordinates);
-  return getGraphBounds(root);
+  const bounds: BoundingBox = { xMin: 0, xMax: 0, yMin: 0, yMax: 0 };
+  updateGraphBounds(root, bounds);
+  return bounds;
 }
 
 /**
@@ -217,13 +219,28 @@ function adjustPositions(
   }
 }
 
-function getGraphBounds(rootNode: AnyGraphNode) {
-  // TODO
-  const bounds: BoundingBox = {
-    xMin: -100,
-    xMax: 100,
-    yMin: -100,
-    yMax: 100,
-  };
-  return bounds;
+function updateGraphBounds(rootNode: AnyGraphNode, result: BoundingBox) {
+  const nodeBounds = rootNode.bounds;
+  if (nodeBounds.xMin < result.xMin) {
+    result.xMin = nodeBounds.xMin;
+  }
+  if (nodeBounds.xMax > result.xMax) {
+    result.xMax = nodeBounds.xMax;
+  }
+  if (nodeBounds.yMin < result.yMin) {
+    result.yMin = nodeBounds.yMin;
+  }
+  if (nodeBounds.yMax > result.yMax) {
+    result.yMax = nodeBounds.yMax;
+  }
+
+  if (rootNode.type === "course") {
+    if (rootNode.state === "open" && rootNode.child) {
+      updateGraphBounds(rootNode.child, result);
+    }
+  } else {
+    for (const child of rootNode.children) {
+      updateGraphBounds(child, result);
+    }
+  }
 }

--- a/components/graphing/setPositions.ts
+++ b/components/graphing/setPositions.ts
@@ -13,6 +13,8 @@ const COURSE_HEIGHT = 20;
 const SET_TOP_PADDING = 20;
 const SET_BOTTOM_PADDING = 10;
 const SET_HORIZONTAL_PADDING = 10;
+const COREQUISITE_OFFSET = 10;
+const COREQUISITE_INTERVAL = COURSE_HEIGHT + Y_INTERVAL / 2;
 
 /**
  * Sets `x`, `y`, `xIn`, `xOut`, `yMin`, and `yMax` where applicable on each
@@ -112,6 +114,10 @@ function positionCourse(
       adjustPositions(node, -subtreeAdjustment, depth, nextYCoordinates);
       maxSubtreeAdjustment -= subtreeAdjustment;
     }
+  }
+  if (node.state === "open" && node.coreqs) {
+    node.bounds.yMax +=
+      node.coreqs.length * COREQUISITE_INTERVAL + COREQUISITE_OFFSET;
   }
 
   nextYCoordinates[depth] = node.bounds.yMax + Y_INTERVAL;

--- a/components/graphing/setPositions.ts
+++ b/components/graphing/setPositions.ts
@@ -1,6 +1,6 @@
 import type { AnyGraphNode, BoundingBox } from "../../utils/graph-schema";
 
-const X_INTERVAL = -200;
+const X_INTERVAL = 200;
 const Y_INTERVAL = 40;
 const COURSE_MAX_WIDTH = 110;
 const HORIZONTAL_MARGIN = 10;
@@ -25,7 +25,7 @@ export function setPositions(root: AnyGraphNode) {
   const yChange = -root.y;
   adjustPositions(root, yChange);
   const bounds: BoundingBox = {
-    xMin: (nextYCoordinates.length - 1) * X_INTERVAL,
+    xMin: (nextYCoordinates.length - 1) * -X_INTERVAL,
     xMax: 0,
     yMin: yChange,
     yMax: Math.max(...nextYCoordinates) - Y_INTERVAL + yChange,
@@ -56,11 +56,11 @@ function setPositionsHelper(
   yEstimate: number,
   nextYCoordinates: number[]
 ) {
-  node.x = depth * X_INTERVAL;
+  node.x = depth * -X_INTERVAL;
   if (depth < nextYCoordinates.length) {
     node.y = Math.max(yEstimate, nextYCoordinates[depth]);
   } else {
-    nextYCoordinates.push(0);
+    nextYCoordinates.push(Number.NEGATIVE_INFINITY);
     node.y = yEstimate;
   }
 
@@ -103,7 +103,7 @@ function setPositionsHelper(
     node.y = (firstChildY + lastChildY) / 2;
     node.xIn = node.bounds.xMin;
     if (node.amount === "all" && !node.isNested) {
-      node.xOut = node.x - X_INTERVAL - HORIZONTAL_MARGIN * 2;
+      node.xOut = node.x + X_INTERVAL - HORIZONTAL_MARGIN * 2;
     } else {
       node.xOut = node.bounds.xMax;
     }

--- a/pages/courses/[code].tsx
+++ b/pages/courses/[code].tsx
@@ -93,7 +93,7 @@ function CoursePage({ course, department }: CoursePageProps) {
           {course.successors ? (
             <>
               <p>
-                {course.code} is a prerequisite for the following{" "}
+                {course.code} is a prerequisite of the following{" "}
                 {course.successors.length} courses:
               </p>
               <ul>

--- a/utils/frontend-cache.ts
+++ b/utils/frontend-cache.ts
@@ -1,24 +1,38 @@
 import { Course } from "./data-schema";
 import { slugifyCourseCode } from ".";
 
-const courseCache = new Map<string, Course | null>();
+const courseCache = new Map<string, Promise<Course | null> | Course | null>();
 
 export async function getCourse(code: string) {
   if (!courseCache.has(code)) {
-    await loadCourse(code);
+    loadCourse(code);
   }
-  return courseCache.get(code) as Course | null;
+  return courseCache.get(code) as Promise<Course | null> | Course | null;
 }
 
-async function loadCourse(code: string) {
-  courseCache.set(code, await fetchFromStaticFiles(code));
+/**
+ * Asynchronously fetches the specified course, filling in the cache with the
+ * pending `Promise`. When the fetch completes, the result (either the course
+ * object or `null`) replaces the `Promise` in the cache and the `Promise`
+ * itself also fulfills with that result. With this logic, we avoid making a
+ * request for a course when other requests are already pending for the same
+ * course.
+ */
+function loadCourse(code: string) {
+  courseCache.set(
+    code,
+    fetchFromStaticFiles(code).then((result) => {
+      courseCache.set(code, result);
+      return result;
+    })
+  );
 }
 
 async function fetchFromStaticFiles(code: string) {
   try {
     const response = await fetch(`/data/${slugifyCourseCode(code)}.json`);
     if (!response.ok) {
-      console.error(`Error retrieving ${code}: status ${response.status}`);
+      // some 404s are expected because the data are not perfectly consistent
       return null;
     }
     const json = await response.json();

--- a/utils/graph-schema.d.ts
+++ b/utils/graph-schema.d.ts
@@ -25,6 +25,8 @@ interface BaseGraphNode {
    * may treat this value differently)
    */
   xOut: number;
+  /** The rectangle that bounds this node in the graph */
+  bounds: BoundingBox;
   /** Whether the node's parent is a set */
   isNested: boolean;
 }
@@ -55,8 +57,6 @@ export interface CourseSetGraphNode extends BaseGraphNode {
   amount: "all" | "one" | "two";
   /** The courses in this set - we may assume there are at least two */
   children: AnyGraphNode[];
-  /** The rectangle that bounds this set in the graph */
-  bounds: BoundingBox;
 }
 
 export type AnyGraphNode = CourseGraphNode | CourseSetGraphNode;

--- a/utils/graph-schema.d.ts
+++ b/utils/graph-schema.d.ts
@@ -55,7 +55,10 @@ export interface CourseSetGraphNode extends BaseGraphNode {
   type: "set";
   /** The amount of courses required to be taken from this set */
   amount: "all" | "one" | "two";
-  /** The courses in this set - we may assume there are at least two */
+  /**
+   * The courses and child sets in this set - we may assume there are at least
+   * two
+   */
   children: AnyGraphNode[];
 }
 

--- a/utils/graph-schema.d.ts
+++ b/utils/graph-schema.d.ts
@@ -41,6 +41,11 @@ export interface CourseGraphNode extends BaseGraphNode {
    */
   child: AnyGraphNode | null;
   /**
+   * A list of corequisite course information, or `null` if there are no
+   * corequisites; a course node handles rendering its own corequisites
+   */
+  coreqs: CoreqInfo[] | null;
+  /**
    * The current state of the node as displayed in the graph; possible values
    * and their meanings are:
    * - `"closed"`: The course has prerequisites and they are currently hidden
@@ -49,6 +54,11 @@ export interface CourseGraphNode extends BaseGraphNode {
    * - `"unknown"`: The course was not found in our data set
    */
   state: "closed" | "open" | "noPrereqs" | "unknown";
+}
+
+export interface CoreqInfo {
+  code: string;
+  exists: boolean;
 }
 
 export interface CourseSetGraphNode extends BaseGraphNode {


### PR DESCRIPTION
## Changes

- Update type definitions
  - Both graph node types now have their own bounding boxes
  - `CourseGraphNode` stores a list of corequisites
- Rewrite graph layout algorithm
  - It now places nodes more optimally and reduces unnecessary space between courses, at the cost of slower runtime complexity (used to be O(n), is now O(n^2) but there is little perceptible difference)
- Display a course's corequisites in the graph
  - `CourseNode` renders its own corequisites too - not as modular as I'd like and there are some magic numbers being reused, but this method simplifies graph generation/layout and only about 0.5% of courses even have corequisites, so I don't think more effort is justifiable
- Prevent frontend cache from making multiple requests for the same course
- Fix effect hook dependencies in `TextWithBackground`

## Resolutions

- Resolves #47
- Resolves #45
- Resolves #53
